### PR TITLE
#81 JSR303 param validation now works on chains of constructors

### DIFF
--- a/src/main/java/com/jcabi/aspects/aj/MethodValidator.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodValidator.java
@@ -110,7 +110,7 @@ public final class MethodValidator {
      * @param point Join point
      * @checkstyle LineLength (3 lines)
      */
-    @Before("initialization(*.new(.., @(javax.validation.* || javax.validation.constraints.*) (*), ..))")
+    @Before("execution(*.new(.., @(javax.validation.* || javax.validation.constraints.*) (*), ..))")
     public void beforeCtor(final JoinPoint point) {
         if (this.validator != null) {
             this.validate(

--- a/src/test/java/com/jcabi/aspects/JSR303Test.java
+++ b/src/test/java/com/jcabi/aspects/JSR303Test.java
@@ -96,7 +96,7 @@ public final class JSR303Test {
      */
     @Test(expected = ConstraintViolationException.class)
     public void validatesConstructorParameters() {
-        new JSR303Test.Bar(null);
+        new JSR303Test.ConstructorValidation(null);
     }
 
     /**
@@ -104,7 +104,7 @@ public final class JSR303Test {
      */
     @Test(expected = ConstraintViolationException.class)
     public void validatesChainedConstructorParameters() {
-        new JSR303Test.Bar();
+        new JSR303Test.ConstructorValidation();
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -153,20 +153,21 @@ public final class JSR303Test {
      * @version $Id$
      */
     @Loggable(Loggable.INFO)
-    private static final class Bar {
+    private static final class ConstructorValidation {
         /**
          * Public ctor.
          * @param param The param.
          * @checkstyle UnusedFormalParameter (2 lines)
          */
-        public Bar(@NotNull final String param) {
+        @SuppressWarnings("PMD.UnusedFormalParameter")
+        public ConstructorValidation(@NotNull final String param) {
             //Nothing to do.
         }
         /**
          * Public ctor that passes null to another ctor.
          * Supposed to fail validation.
          */
-        public Bar() {
+        public ConstructorValidation() {
             this(null);
         }
 


### PR DESCRIPTION
Note that I first tried using `preinitialization(*.new...)` as suggested in #81, but it failed the unit tests that I created. It worked perfectly using `execution(*.new...)` so that's what I went with.
