### PR TITLE
Use proper source-filtering instead of resource-filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,19 +93,6 @@
         </dependency>
     </dependencies>
     <build>
-        <!-- Comment this line if you don't see source code in your IDE -->
-        <sourceDirectory>${project.build.directory}/filtered-sources/java</sourceDirectory>
-        <resources>
-            <resource>
-                <directory>${basedir}/src/main/java</directory>
-                <filtering>true</filtering>
-                <targetPath>${project.build.directory}/filtered-sources/java</targetPath>
-            </resource>
-            <resource>
-                <directory>${basedir}/src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -154,6 +141,24 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0-alpha-3</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/java-templates</sourceDirectory>
+                    <outputDirectory>${project.build.directory}/generated-sources/java-templates/</outputDirectory>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java-templates/com/jcabi/aspects/version/Version.java
+++ b/src/main/java-templates/com/jcabi/aspects/version/Version.java
@@ -27,66 +27,54 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.jcabi.aspects.aj;
-
-import com.jcabi.aspects.version.Version;
-import com.jcabi.log.Logger;
-import java.util.concurrent.ThreadFactory;
+package com.jcabi.aspects.version;
 
 /**
- * Factory of named threads, used in {@link MethodLogger},
- * {@link MethodCacher}, {@link MethodInterrupter}, etc.
- *
- * <p>This custom class is used instead of a default ThreadFactory in order
- * to name scheduled threads correctly on construction.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
+ * Current version of the project. Generated from a template at build time.
+ * @author Georgy Vlasov (wlasowegor@gmail.com)
  * @version $Id$
- * @since 0.7.17
+ * @since 0.23
  */
-@SuppressWarnings("PMD.DoNotUseThreads")
-final class NamedThreads implements ThreadFactory {
+public enum Version {
+    /**
+     * Current version.
+     */
+    CURRENT("${project.version}", "${buildNumber}");
 
     /**
-     * Name of the thread.
+     * Project version.
      */
-    private final transient String name;
+    private final String version;
 
     /**
-     * Purpose of these threads.
+     * Build number.
      */
-    private final transient String purpose;
-
-    /**
-     * Thread group to use.
-     */
-    private final transient ThreadGroup group = new ThreadGroup("jcabi");
+    private final String build;
 
     /**
      * Public ctor.
-     * @param suffix Suffix of thread names
-     * @param desc Description of purpose
+     * @param ver Maven's project.version property
+     * @param buildnum Maven's buildNumber property created with
+     *  buildnumber-maven-plugin
      */
-    public NamedThreads(final String suffix, final String desc) {
-        this.name = String.format("jcabi-%s", suffix);
-        this.purpose = desc;
+    Version(final String ver, final String buildnum) {
+        this.version = ver;
+        this.build = buildnum;
     }
 
-    @Override
-    public Thread newThread(final Runnable runnable) {
-        final Thread thread = new Thread(this.group, runnable);
-        thread.setName(this.name);
-        thread.setDaemon(true);
-        Logger.info(
-            this,
-            // @checkstyle LineLength (1 line)
-            "jcabi-aspects %s/%s started new daemon thread %s for %s",
-            Version.CURRENT.projectVersion(),
-            Version.CURRENT.buildNumber(),
-            this.name,
-            this.purpose
-        );
-        return thread;
+    /**
+     * Returns project version number.
+     * @return Project version number
+     */
+    public String projectVersion() {
+        return this.version;
     }
 
+    /**
+     * Returns project build number.
+     * @return Build number
+     */
+    public String buildNumber() {
+        return this.build;
+    }
 }

--- a/src/main/java-templates/com/jcabi/aspects/version/package-info.java
+++ b/src/main/java-templates/com/jcabi/aspects/version/package-info.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Contains a class generated from a template that is used to access project
+ * version and build number.
+ * @author Georgy Vlasov (wlasowegor@gmail.com)
+ * @version $Id$
+ * @since 0.23
+ */
+package com.jcabi.aspects.version;

--- a/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
+++ b/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
@@ -30,6 +30,7 @@
 package com.jcabi.aspects.aj;
 
 import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.version.Version;
 import com.jcabi.log.Logger;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -73,8 +74,10 @@ public final class ImmutabilityChecker {
             throw new IllegalStateException(
                 String.format(
                     // @checkstyle LineLength (1 line)
-                    "%s is not immutable, can't use it (jcabi-aspects ${project.version}/${buildNumber})",
-                    type
+                    "%s is not immutable, can't use it (jcabi-aspects %s/%s)",
+                    type,
+                    Version.CURRENT.projectVersion(),
+                    Version.CURRENT.buildNumber()
                 ),
                 ex
             );

--- a/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
+++ b/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
@@ -74,6 +74,10 @@ public final class ImmutabilityChecker {
             throw new IllegalStateException(
                 String.format(
                     // @checkstyle LineLength (1 line)
+                    // @todo #167:30min Inserting correct version/buildnumber
+                    //  here and in other instances where Version.CURRENT is
+                    //  used (not only in this class, but in every class that
+                    //  uses Version.CURRENT) should be covered by a test.
                     "%s is not immutable, can't use it (jcabi-aspects %s/%s)",
                     type,
                     Version.CURRENT.projectVersion(),

--- a/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
+++ b/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
@@ -62,7 +62,10 @@ public final class ImmutabilityChecker {
      *
      * <p>Try NOT to change the signature of this method, in order to keep
      * it backward compatible.
-     *
+     * @todo #167:30min Inserting correct version/buildnumber
+     *  here and in other instances where Version.CURRENT is
+     *  used (not only in this class, but in every class that
+     *  uses Version.CURRENT) should be covered by a test.
      * @param point Joint point
      */
     @After("initialization((@com.jcabi.aspects.Immutable *).new(..))")
@@ -74,10 +77,6 @@ public final class ImmutabilityChecker {
             throw new IllegalStateException(
                 String.format(
                     // @checkstyle LineLength (1 line)
-                    // @todo #167:30min Inserting correct version/buildnumber
-                    //  here and in other instances where Version.CURRENT is
-                    //  used (not only in this class, but in every class that
-                    //  uses Version.CURRENT) should be covered by a test.
                     "%s is not immutable, can't use it (jcabi-aspects %s/%s)",
                     type,
                     Version.CURRENT.projectVersion(),

--- a/src/test/java/com/jcabi/aspects/version/VersionTest.java
+++ b/src/test/java/com/jcabi/aspects/version/VersionTest.java
@@ -27,66 +27,47 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.jcabi.aspects.aj;
+package com.jcabi.aspects.version;
 
-import com.jcabi.aspects.version.Version;
-import com.jcabi.log.Logger;
-import java.util.concurrent.ThreadFactory;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * Factory of named threads, used in {@link MethodLogger},
- * {@link MethodCacher}, {@link MethodInterrupter}, etc.
- *
- * <p>This custom class is used instead of a default ThreadFactory in order
- * to name scheduled threads correctly on construction.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
+ * Unit tests for {@link Version}.
+ * @author Georgy Vlasov (wlasowegor@gmail.com)
  * @version $Id$
- * @since 0.7.17
+ * @since 0.23
  */
-@SuppressWarnings("PMD.DoNotUseThreads")
-final class NamedThreads implements ThreadFactory {
+public final class VersionTest {
 
     /**
-     * Name of the thread.
+     * Version.CURRENT contains actual project version and not a
+     * "${project.version}" placeholder.
+     * @throws Exception If fails
      */
-    private final transient String name;
-
-    /**
-     * Purpose of these threads.
-     */
-    private final transient String purpose;
-
-    /**
-     * Thread group to use.
-     */
-    private final transient ThreadGroup group = new ThreadGroup("jcabi");
-
-    /**
-     * Public ctor.
-     * @param suffix Suffix of thread names
-     * @param desc Description of purpose
-     */
-    public NamedThreads(final String suffix, final String desc) {
-        this.name = String.format("jcabi-%s", suffix);
-        this.purpose = desc;
-    }
-
-    @Override
-    public Thread newThread(final Runnable runnable) {
-        final Thread thread = new Thread(this.group, runnable);
-        thread.setName(this.name);
-        thread.setDaemon(true);
-        Logger.info(
-            this,
-            // @checkstyle LineLength (1 line)
-            "jcabi-aspects %s/%s started new daemon thread %s for %s",
+    @Test
+    public void projectVersionIsInsertedAtBuild() throws Exception {
+        MatcherAssert.assertThat(
             Version.CURRENT.projectVersion(),
-            Version.CURRENT.buildNumber(),
-            this.name,
-            this.purpose
+            Matchers.not(
+                Matchers.equalTo("${projectVersion}")
+            )
         );
-        return thread;
     }
 
+    /**
+     * Version.CURRENT contains actual build number and not a
+     * "${buildNumber}" placeholder.
+     * @throws Exception If fails
+     */
+    @Test
+    public void buildNumberIsInsertedAtBuild() throws Exception {
+        MatcherAssert.assertThat(
+            Version.CURRENT.buildNumber(),
+            Matchers.not(
+                Matchers.equalTo("${buildNumber}")
+            )
+        );
+    }
 }

--- a/src/test/java/com/jcabi/aspects/version/VersionTest.java
+++ b/src/test/java/com/jcabi/aspects/version/VersionTest.java
@@ -42,12 +42,12 @@ import org.junit.Test;
 public final class VersionTest {
 
     /**
-     * Version.CURRENT contains actual project version and not a
+     * Version.CURRENT can contain actual project version and not a
      * "${project.version}" placeholder.
      * @throws Exception If fails
      */
     @Test
-    public void projectVersionIsInsertedAtBuild() throws Exception {
+    public void containsCorrectVersionNumber() throws Exception {
         MatcherAssert.assertThat(
             Version.CURRENT.projectVersion(),
             Matchers.not(
@@ -57,12 +57,12 @@ public final class VersionTest {
     }
 
     /**
-     * Version.CURRENT contains actual build number and not a
+     * Version.CURRENT can contain actual build number and not a
      * "${buildNumber}" placeholder.
      * @throws Exception If fails
      */
     @Test
-    public void buildNumberIsInsertedAtBuild() throws Exception {
+    public void containsCorrectBuildNumber() throws Exception {
         MatcherAssert.assertThat(
             Version.CURRENT.buildNumber(),
             Matchers.not(

--- a/src/test/java/com/jcabi/aspects/version/package-info.java
+++ b/src/test/java/com/jcabi/aspects/version/package-info.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Project version and buildNumber generated at build time, tests.
+ * @author Georgy Vlasov (wlasowegor@gmail.com)
+ * @version $Id$
+ * @since 0.23
+ */
+package com.jcabi.aspects.version;


### PR DESCRIPTION
The issue was that in pom.xml, `src/main/java` was marked as a resource directory in order to use resource filtering to insert project version and buildNumber into some classes at build time. And that made IntelliJ IDEA (and probably other IDEs, too) treat all the sources as resource directories, disabling some source editing features.

In #167, I suggested to use `replacer` plugin instead of standard resource filtering, but later found an even better alternative, which is `templating-maven-plugin`.

I moved all the templates for sources in a separate java-templates directory and set up source generation with `templating-maven-plugin` so IntelliJ IDEA treats the rest of sources as actual Java source code.

Fixes #167