### PR TITLE
issue #173: updating dependecies. hibernate-validator up to 5.2.1. ad…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,13 @@
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
             <version>2.2.4</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.el</artifactId>
             <version>2.2.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,18 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.0.0.Final</version>
+            <version>5.2.1.Final</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>2.2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>2.2.4</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
When our own validation was replaced with hibernate-validator for #34, this test stopped working in openJDK6, but remained working in all the other JDKs we're using on Travis CI.

Fixed: 
added necessary dependencies for hibernate-validator: 
java.el-api:javax.el:2.2.4
org.glassfish.web:javax.el:2.2.4

Code was not changed. 