### PR TITLE
Pull requst for issue 173

### DIFF
--- a/src/test/java/com/jcabi/aspects/JSR303Test.java
+++ b/src/test/java/com/jcabi/aspects/JSR303Test.java
@@ -37,7 +37,6 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/jcabi/aspects/JSR303Test.java
+++ b/src/test/java/com/jcabi/aspects/JSR303Test.java
@@ -64,7 +64,6 @@ public final class JSR303Test {
      *  This test should pass without errors.
      * @throws Exception If something goes wrong
      */
-    @Ignore
     @Test(expected = ConstraintViolationException.class)
     public void throwsWhenRegularExpressionDoesntMatch() throws Exception {
         new JSR303Test.Foo().foo("some text");


### PR DESCRIPTION
issue #173 : this test was stopped working in openJDK6, but remained working in all the other JDKs we're using on Travis CI. This test should pass without errors.... 

removed @Ignore annotation to check this behaving. 
