### PR TITLE
Add a method to asynchronously update the expiration cache

### DIFF
--- a/src/main/java/com/jcabi/aspects/Cacheable.java
+++ b/src/main/java/com/jcabi/aspects/Cacheable.java
@@ -104,7 +104,8 @@ public @interface Cacheable {
     boolean forever() default false;
 
     /**
-     *  Returns the current store after the expiration, and then asynchronously update the data
+     * Returns the current store after the expiration, and
+     * then asynchronously update the data.
      */
     boolean asyncUpdate() default false;
 

--- a/src/main/java/com/jcabi/aspects/Cacheable.java
+++ b/src/main/java/com/jcabi/aspects/Cacheable.java
@@ -104,6 +104,11 @@ public @interface Cacheable {
     boolean forever() default false;
 
     /**
+     *  Returns the current store after the expiration, and then asynchronously update the data
+     */
+    boolean asyncUpdate() default false;
+
+    /**
      * Before-flushing trigger(s).
      *
      * <p>Before calling the method, call static method {@code flushBefore()}

--- a/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
@@ -36,7 +36,6 @@ import com.jcabi.log.VerboseRunnable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -44,6 +43,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.After;
@@ -77,9 +77,9 @@ public final class MethodCacher {
         new ConcurrentHashMap<MethodCacher.Key, MethodCacher.Tunnel>(0);
 
     /**
-     * save the keys which need update.
+     * Save the keys which need update.
      */
-    private final transient BlockingQueue<MethodCacher.Key> updateKeys =
+    private final transient BlockingQueue<MethodCacher.Key> updatekeys =
         new LinkedBlockingQueue<MethodCacher.Key>();
 
     /**
@@ -121,12 +121,12 @@ public final class MethodCacher {
         );
         this.updater.schedule(
             new VerboseRunnable(
-                 new Runnable() {
-                     @Override
-                     public void run() {
-                         MethodCacher.this.update();
-                     }
-                 }
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        MethodCacher.this.update();
+                    }
+                }
             ),
             0L, TimeUnit.SECONDS
         );
@@ -173,7 +173,7 @@ public final class MethodCacher {
                     );
                     this.tunnels.put(key, tunnel);
                 } else {
-                    this.updateKeys.offer(key);
+                    this.updatekeys.offer(key);
                 }
             }
             for (final Class<?> after : annot.after()) {
@@ -301,7 +301,7 @@ public final class MethodCacher {
         final String format = "%s:%s";
         while (true) {
             try {
-                final MethodCacher.Key key = updateKeys.take();
+                final MethodCacher.Key key = this.updatekeys.take();
                 final MethodCacher.Tunnel tunnel = this.tunnels.get(key);
                 if (tunnel != null && tunnel.expired()) {
                     final MethodCacher.Tunnel newTunnel =
@@ -344,7 +344,7 @@ public final class MethodCacher {
         /**
          * Whether asynchronous update.
          */
-        private final transient boolean asyncUpdate;
+        private final transient boolean asyncupdate;
         /**
          * Was it already executed?
          */
@@ -365,20 +365,20 @@ public final class MethodCacher {
         Tunnel(final MethodCacher.Tunnel tunnel) {
             this.point = tunnel.point;
             this.key = tunnel.key;
-            this.asyncUpdate = tunnel.asyncUpdate;
+            this.asyncupdate = tunnel.asyncupdate;
         }
 
         /**
          * Public ctor.
          * @param pnt ProceedingJoinPoint
          * @param akey MethodCacher.Key
-         * @param asyncUpdate boolean
+         * @param aupdate Boolean
          */
         Tunnel(final ProceedingJoinPoint pnt,
-            final MethodCacher.Key akey, final boolean asyncUpdate) {
+            final MethodCacher.Key akey, final boolean aupdate) {
             this.point = pnt;
             this.key = akey;
-            this.asyncUpdate = asyncUpdate;
+            this.asyncupdate = aupdate;
         }
 
         @Override
@@ -445,7 +445,7 @@ public final class MethodCacher {
          * @return TRUE if asynchronous update
          */
         public boolean asyncUpdate() {
-            return asyncUpdate;
+            return this.asyncupdate;
         }
     }
 

--- a/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
@@ -70,10 +70,10 @@ public final class MethodCacher {
      * @checkstyle LineLength (2 lines)
      */
     private final transient ConcurrentMap<MethodCacher.Key, MethodCacher.Tunnel> tunnels =
-        new ConcurrentHashMap<Key, Tunnel>(0);
+        new ConcurrentHashMap<MethodCacher.Key, MethodCacher.Tunnel>(0);
 
     /**
-     * Save the keys which need update.
+     * Save the keys of caches which need update.
      */
     private final transient BlockingQueue<Key> updatekeys =
         new LinkedBlockingQueue<MethodCacher.Key>();
@@ -136,23 +136,13 @@ public final class MethodCacher {
     }
 
     /**
-     * Whether create a new Tunnel.
-     * @param tunnel MethodCacher.Tunnel
-     * @return Boolean
-     */
-    private boolean isCreateTunnel(final MethodCacher.Tunnel tunnel) {
-        return tunnel == null || (tunnel.expired() && !tunnel.asyncUpdate());
-    }
-
-    /**
      * Flush cache.
      * @param point Join point
      * @return Value of the method
      * @since 0.7.14
      * @deprecated Since 0.7.17, and preflush() should be used
      * @throws Throwable If something goes wrong inside
-     * @checkstyle IllegalThrows (4 lines)
-     * @checkstyle MethodsOrderCheck (3 lines)
+     * @checkstyle IllegalThrows (3 lines)
      */
     @Deprecated
     public Object flush(final ProceedingJoinPoint point) throws Throwable {
@@ -168,7 +158,6 @@ public final class MethodCacher {
      *
      * @param point Joint point
      * @since 0.7.14
-     * @checkstyle MethodsOrderCheck (3 lines)
      */
     @Before(
         // @checkstyle StringLiteralsConcatenation (3 lines)
@@ -188,7 +177,6 @@ public final class MethodCacher {
      *
      * @param point Joint point
      * @since 0.7.18
-     * @checkstyle MethodsOrderCheck (3 lines)
      */
     @After(
         // @checkstyle StringLiteralsConcatenation (2 lines)
@@ -233,6 +221,15 @@ public final class MethodCacher {
     }
 
     /**
+     * Whether create a new Tunnel.
+     * @param tunnel MethodCacher.Tunnel
+     * @return Boolean
+     */
+    private boolean isCreateTunnel(final MethodCacher.Tunnel tunnel) {
+        return tunnel == null || (tunnel.expired() && !tunnel.asyncUpdate());
+    }
+
+    /**
      * Mutable caching/calling tunnel, it is thread-safe.
      */
     protected static final class Tunnel {
@@ -247,7 +244,7 @@ public final class MethodCacher {
         /**
          * Whether asynchronous update.
          */
-        private final transient boolean asynchupdate;
+        private final transient boolean async;
         /**
          * Was it already executed?
          */
@@ -265,13 +262,13 @@ public final class MethodCacher {
          * Public ctor.
          * @param pnt ProceedingJoinPoint
          * @param akey MethodCacher.Key
-         * @param aupdate Boolean
+         * @param asy Boolean
          */
         Tunnel(final ProceedingJoinPoint pnt,
-            final MethodCacher.Key akey, final boolean aupdate) {
+            final MethodCacher.Key akey, final boolean asy) {
             this.point = pnt;
             this.key = akey;
-            this.asynchupdate = aupdate;
+            this.async = asy;
         }
 
         @Override
@@ -280,12 +277,12 @@ public final class MethodCacher {
         }
 
         /**
-         * Public ctor.
+         * Get a new instance.
          * @return MethodCacher.Tunnel
          */
         public Tunnel copy() {
             return new Tunnel(
-                this.point, this.key, this.asynchupdate
+                this.point, this.key, this.async
             );
         }
         /**
@@ -348,7 +345,7 @@ public final class MethodCacher {
          * @return TRUE if asynchronous update
          */
         public boolean asyncUpdate() {
-            return this.asynchupdate;
+            return this.async;
         }
     }
 

--- a/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
@@ -161,20 +161,14 @@ public final class MethodCacher {
                 }
             }
             tunnel = this.tunnels.get(key);
-            if (tunnel == null) {
+            if (this.isCreateTunnel(tunnel)) {
                 tunnel = new MethodCacher.Tunnel(
                     point, key, annot.asyncUpdate()
                 );
                 this.tunnels.put(key, tunnel);
-            } else if (tunnel.expired()) {
-                if (!tunnel.asyncUpdate()) {
-                    tunnel = new MethodCacher.Tunnel(
-                        point, key, annot.asyncUpdate()
-                    );
-                    this.tunnels.put(key, tunnel);
-                } else {
-                    this.updatekeys.offer(key);
-                }
+            }
+            if (tunnel.expired() && tunnel.asyncUpdate()) {
+                this.updatekeys.offer(key);
             }
             for (final Class<?> after : annot.after()) {
                 final boolean flag = Boolean.class.cast(
@@ -186,6 +180,15 @@ public final class MethodCacher {
             }
         }
         return tunnel.through();
+    }
+
+    /**
+     * Whether create a new Tunnel.
+     * @param tunnel MethodCacher.Tunnel
+     * @return Boolean
+     */
+    private boolean isCreateTunnel(final MethodCacher.Tunnel tunnel) {
+        return tunnel == null || (tunnel.expired() && !tunnel.asyncUpdate());
     }
 
     /**
@@ -304,6 +307,7 @@ public final class MethodCacher {
                 final MethodCacher.Key key = this.updatekeys.take();
                 final MethodCacher.Tunnel tunnel = this.tunnels.get(key);
                 if (tunnel != null && tunnel.expired()) {
+                    // @checkstyle AvoidInstantiatingObjectsInLoops (1 line)
                     final MethodCacher.Tunnel newTunnel =
                         new MethodCacher.Tunnel(tunnel);
                     newTunnel.through();
@@ -345,7 +349,7 @@ public final class MethodCacher {
         /**
          * Whether asynchronous update.
          */
-        private final transient boolean asyncupdate;
+        private final transient boolean asynchupdate;
         /**
          * Was it already executed?
          */
@@ -366,7 +370,7 @@ public final class MethodCacher {
         Tunnel(final MethodCacher.Tunnel tunnel) {
             this.point = tunnel.point;
             this.key = tunnel.key;
-            this.asyncupdate = tunnel.asyncupdate;
+            this.asynchupdate = tunnel.asynchupdate;
         }
 
         /**
@@ -379,7 +383,7 @@ public final class MethodCacher {
             final MethodCacher.Key akey, final boolean aupdate) {
             this.point = pnt;
             this.key = akey;
-            this.asyncupdate = aupdate;
+            this.asynchupdate = aupdate;
         }
 
         @Override
@@ -446,7 +450,7 @@ public final class MethodCacher {
          * @return TRUE if asynchronous update
          */
         public boolean asyncUpdate() {
-            return this.asyncupdate;
+            return this.asynchupdate;
         }
     }
 

--- a/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
@@ -66,7 +66,9 @@ import org.aspectj.lang.reflect.MethodSignature;
  * @since 0.8
  */
 @Aspect
-@SuppressWarnings({ "PMD.DoNotUseThreads", "PMD.TooManyMethods" })
+@SuppressWarnings(
+    { "PMD.DoNotUseThreads", "PMD.TooManyMethods", "PMD.GodClass" }
+)
 public final class MethodCacher {
 
     /**
@@ -198,7 +200,8 @@ public final class MethodCacher {
      * @since 0.7.14
      * @deprecated Since 0.7.17, and preflush() should be used
      * @throws Throwable If something goes wrong inside
-     * @checkstyle IllegalThrows (3 lines)
+     * @checkstyle IllegalThrows (4 lines)
+     * @checkstyle MethodsOrderCheck (3 lines)
      */
     @Deprecated
     public Object flush(final ProceedingJoinPoint point) throws Throwable {
@@ -214,6 +217,7 @@ public final class MethodCacher {
      *
      * @param point Joint point
      * @since 0.7.14
+     * @checkstyle MethodsOrderCheck (3 lines)
      */
     @Before(
         // @checkstyle StringLiteralsConcatenation (3 lines)
@@ -233,6 +237,7 @@ public final class MethodCacher {
      *
      * @param point Joint point
      * @since 0.7.18
+     * @checkstyle MethodsOrderCheck (3 lines)
      */
     @After(
         // @checkstyle StringLiteralsConcatenation (2 lines)
@@ -307,9 +312,7 @@ public final class MethodCacher {
                 final MethodCacher.Key key = this.updatekeys.take();
                 final MethodCacher.Tunnel tunnel = this.tunnels.get(key);
                 if (tunnel != null && tunnel.expired()) {
-                    // @checkstyle AvoidInstantiatingObjectsInLoops (1 line)
-                    final MethodCacher.Tunnel newTunnel =
-                        new MethodCacher.Tunnel(tunnel);
+                    final MethodCacher.Tunnel newTunnel = tunnel.copy();
                     newTunnel.through();
                     this.tunnels.put(key, newTunnel);
                 }
@@ -365,16 +368,6 @@ public final class MethodCacher {
 
         /**
          * Public ctor.
-         * @param tunnel MethodCacher.Tunnel
-         */
-        Tunnel(final MethodCacher.Tunnel tunnel) {
-            this.point = tunnel.point;
-            this.key = tunnel.key;
-            this.asynchupdate = tunnel.asynchupdate;
-        }
-
-        /**
-         * Public ctor.
          * @param pnt ProceedingJoinPoint
          * @param akey MethodCacher.Key
          * @param aupdate Boolean
@@ -389,6 +382,16 @@ public final class MethodCacher {
         @Override
         public String toString() {
             return Mnemos.toText(this.cached, true, false);
+        }
+
+        /**
+         * Public ctor.
+         * @return MethodCacher.Tunnel
+         */
+        public Tunnel copy() {
+            return new Tunnel(
+                this.point, this.key, this.asynchupdate
+            );
         }
         /**
          * Get a result through the tunnel.

--- a/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
@@ -297,8 +297,8 @@ public final class MethodCacher {
     /**
      * Update cache.
      */
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
     private void update() {
-        final String format = "%s:%s";
         while (true) {
             try {
                 final MethodCacher.Key key = this.updatekeys.take();
@@ -313,17 +313,17 @@ public final class MethodCacher {
                 LogHelper.log(
                     Loggable.ERROR,
                     this,
-                    format,
+                    "%s:%s",
                     ex.getMessage(),
                     ex
                 );
-            } catch (final Throwable throwable) {
-                LogHelper.log(
-                    Loggable.ERROR,
-                    this,
-                    format,
-                    throwable.getMessage(),
-                    throwable
+            } catch (final Throwable ex) {
+                throw new IllegalStateException(
+                    String.format(
+                        "%s: Exception thrown",
+                        ex.getMessage()
+                    ),
+                    ex
                 );
             }
         }

--- a/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodCacher.java
@@ -317,12 +317,13 @@ public final class MethodCacher {
                     ex.getMessage(),
                     ex
                 );
+            // @checkstyle IllegalCatch (1 line)
             } catch (final Throwable ex) {
-                throw new IllegalStateException(
-                    String.format(
-                        "%s: Exception thrown",
-                        ex.getMessage()
-                    ),
+                LogHelper.log(
+                    Loggable.ERROR,
+                    this,
+                    "Exception message is %s, Exception is %s",
+                    ex.getMessage(),
                     ex
                 );
             }

--- a/src/main/java/com/jcabi/aspects/aj/UpdateMethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/UpdateMethodCacher.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.aspects.aj;
+
+import com.jcabi.aspects.Loggable;
+import com.jcabi.log.VerboseRunnable;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * For updating cache and cleaning expired cache.
+ * @author Peng Chuanjiang (pengchuanjiang@souyidai.com)
+ * @version $Id$
+ */
+@SuppressWarnings("PMD.DoNotUseThreads")
+public final class UpdateMethodCacher {
+
+    /**
+     * Calling tunnels.
+     * @checkstyle LineLength (2 lines)
+     */
+    private final transient ConcurrentMap<MethodCacher.Key, MethodCacher.Tunnel> tunnels;
+
+    /**
+     * Service that cleans cache.
+     */
+    private final transient ScheduledExecutorService cleaner =
+        Executors.newSingleThreadScheduledExecutor(
+            new NamedThreads(
+                "cacheable-clean",
+                "automated cleaning of expired @Cacheable values"
+            )
+        );
+
+    /**
+     * Save the keys which need update.
+     */
+    private final transient BlockingQueue<MethodCacher.Key> updatekeys;
+
+    /**
+     * Service that update cache.
+     */
+    private final transient ScheduledExecutorService updater =
+        Executors.newSingleThreadScheduledExecutor(
+            new NamedThreads(
+                "cacheable-update",
+                "async update of expired @Cacheable values"
+            )
+        );
+
+    /**
+     * Public ctor.
+     * @param tls ConcurrentMap
+     * @param ukeys BlockingQueue
+     */
+    public UpdateMethodCacher(
+        final ConcurrentMap<MethodCacher.Key, MethodCacher.Tunnel> tls,
+        final BlockingQueue<MethodCacher.Key> ukeys) {
+        this.tunnels = tls;
+        this.updatekeys = ukeys;
+    }
+
+    /**
+     * Staring two threads(cheaner and updater) are used for
+     * updating cache and cleaning expired cache.
+     */
+    public void start() {
+        this.cleaner.scheduleWithFixedDelay(
+            new VerboseRunnable(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        UpdateMethodCacher.this.clean();
+                    }
+                }
+            ),
+            1L, 1L, TimeUnit.SECONDS
+        );
+        this.updater.schedule(
+            new VerboseRunnable(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        UpdateMethodCacher.this.update();
+                    }
+                }
+            ),
+            0L, TimeUnit.SECONDS
+        );
+    }
+
+    /**
+     * Clean cache.
+     */
+    private void clean() {
+        synchronized (this.tunnels) {
+            for (final MethodCacher.Key key : this.tunnels.keySet()) {
+                if (this.tunnels.get(key).expired()
+                    && !this.tunnels.get(key).asyncUpdate()) {
+                    final MethodCacher.Tunnel tunnel = this.tunnels.remove(key);
+                    LogHelper.log(
+                        key.getLevel(),
+                        this,
+                        "%s:%s expired in cache",
+                        key,
+                        tunnel
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Update cache.
+     */
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    private void update() {
+        while (true) {
+            try {
+                final MethodCacher.Key key = this.updatekeys.take();
+                final MethodCacher.Tunnel tunnel = this.tunnels.get(key);
+                if (tunnel != null && tunnel.expired()) {
+                    final MethodCacher.Tunnel newTunnel = tunnel.copy();
+                    newTunnel.through();
+                    this.tunnels.put(key, newTunnel);
+                }
+            } catch (final InterruptedException ex) {
+                LogHelper.log(
+                    Loggable.ERROR,
+                    this,
+                    "%s:%s",
+                    ex.getMessage(),
+                    ex
+                );
+                // @checkstyle IllegalCatch (1 line)
+            } catch (final Throwable ex) {
+                LogHelper.log(
+                    Loggable.ERROR,
+                    this,
+                    "Exception message is %s, Exception is %s",
+                    ex.getMessage(),
+                    ex
+                );
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/jcabi/aspects/aj/UpdateMethodCacher.java
+++ b/src/main/java/com/jcabi/aspects/aj/UpdateMethodCacher.java
@@ -63,7 +63,7 @@ public final class UpdateMethodCacher {
         );
 
     /**
-     * Save the keys which need update.
+     * Save the keys of caches which need update.
      */
     private final transient BlockingQueue<MethodCacher.Key> updatekeys;
 

--- a/src/test/java/com/jcabi/aspects/CacheableTest.java
+++ b/src/test/java/com/jcabi/aspects/CacheableTest.java
@@ -78,7 +78,7 @@ public final class CacheableTest {
      * @throws Exception If something goes wrong
      */
     @Test
-    public void asyncUpdateCacheSimpleCall() {
+    public void asyncUpdateCacheSimpleCall() throws Exception {
         final CacheableTest.Foo foo = new CacheableTest.Foo(1L);
         final String first = foo.asyncGet().toString();
         final String second = foo.asyncGet().toString();
@@ -97,7 +97,6 @@ public final class CacheableTest {
         }
         final String forth = foo.asyncGet().toString();
         MatcherAssert.assertThat(first, Matchers.not(Matchers.equalTo(forth)));
-        MatcherAssert.assertThat(thrid, Matchers.equalTo(thrid));
     }
 
     /**
@@ -228,6 +227,10 @@ public final class CacheableTest {
             return new CacheableTest.Foo(CacheableTest.RANDOM.nextLong());
         }
 
+        /**
+         * Download some text.
+         * @return Downloaded text
+         */
         @Cacheable(lifetime = 1, unit = TimeUnit.SECONDS, asyncUpdate = true)
         @Loggable(Loggable.DEBUG)
         public CacheableTest.Foo asyncGet() {

--- a/src/test/java/com/jcabi/aspects/CacheableTest.java
+++ b/src/test/java/com/jcabi/aspects/CacheableTest.java
@@ -85,15 +85,15 @@ public final class CacheableTest {
         MatcherAssert.assertThat(first, Matchers.equalTo(second));
         try {
             TimeUnit.SECONDS.sleep(2);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+        } catch (final InterruptedException ex) {
+            throw new IllegalStateException(ex);
         }
         final String thrid = foo.asyncGet().toString();
         MatcherAssert.assertThat(first, Matchers.equalTo(thrid));
         try {
             TimeUnit.SECONDS.sleep(2);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+        } catch (final InterruptedException ex) {
+            throw new IllegalStateException(ex);
         }
         final String forth = foo.asyncGet().toString();
         MatcherAssert.assertThat(first, Matchers.not(Matchers.equalTo(forth)));

--- a/src/test/java/com/jcabi/aspects/CacheableTest.java
+++ b/src/test/java/com/jcabi/aspects/CacheableTest.java
@@ -81,22 +81,20 @@ public final class CacheableTest {
     public void asyncUpdateCacheSimpleCall() throws Exception {
         final CacheableTest.Foo foo = new CacheableTest.Foo(1L);
         final String first = foo.asyncGet().toString();
-        final String second = foo.asyncGet().toString();
-        MatcherAssert.assertThat(first, Matchers.equalTo(second));
-        try {
-            TimeUnit.SECONDS.sleep(2);
-        } catch (final InterruptedException ex) {
-            throw new IllegalStateException(ex);
-        }
-        final String thrid = foo.asyncGet().toString();
-        MatcherAssert.assertThat(first, Matchers.equalTo(thrid));
-        try {
-            TimeUnit.SECONDS.sleep(2);
-        } catch (final InterruptedException ex) {
-            throw new IllegalStateException(ex);
-        }
-        final String forth = foo.asyncGet().toString();
-        MatcherAssert.assertThat(first, Matchers.not(Matchers.equalTo(forth)));
+        MatcherAssert.assertThat(
+            first,
+            Matchers.equalTo(foo.asyncGet().toString())
+        );
+        TimeUnit.SECONDS.sleep(2);
+        MatcherAssert.assertThat(
+            first,
+            Matchers.equalTo(foo.asyncGet().toString())
+        );
+        TimeUnit.SECONDS.sleep(2);
+        MatcherAssert.assertThat(
+            first,
+            Matchers.not(Matchers.equalTo(foo.asyncGet().toString()))
+        );
     }
 
     /**

--- a/src/test/java/com/jcabi/aspects/CacheableTest.java
+++ b/src/test/java/com/jcabi/aspects/CacheableTest.java
@@ -74,6 +74,33 @@ public final class CacheableTest {
     }
 
     /**
+     * Cacheable can Asynchronous update.
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public void asyncUpdateCacheSimpleCall() {
+        final CacheableTest.Foo foo = new CacheableTest.Foo(1L);
+        final String first = foo.asyncGet().toString();
+        final String second = foo.asyncGet().toString();
+        MatcherAssert.assertThat(first, Matchers.equalTo(second));
+        try {
+            TimeUnit.SECONDS.sleep(2);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        final String thrid = foo.asyncGet().toString();
+        MatcherAssert.assertThat(first, Matchers.equalTo(thrid));
+        try {
+            TimeUnit.SECONDS.sleep(2);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        final String forth = foo.asyncGet().toString();
+        MatcherAssert.assertThat(first, Matchers.not(Matchers.equalTo(forth)));
+        MatcherAssert.assertThat(thrid, Matchers.equalTo(thrid));
+    }
+
+    /**
      * Cacheable can cache static calls.
      * @throws Exception If something goes wrong
      */
@@ -198,6 +225,12 @@ public final class CacheableTest {
         @Cacheable(lifetime = 1, unit = TimeUnit.SECONDS)
         @Loggable(Loggable.DEBUG)
         public CacheableTest.Foo get() {
+            return new CacheableTest.Foo(CacheableTest.RANDOM.nextLong());
+        }
+
+        @Cacheable(lifetime = 1, unit = TimeUnit.SECONDS, asyncUpdate = true)
+        @Loggable(Loggable.DEBUG)
+        public CacheableTest.Foo asyncGet() {
             return new CacheableTest.Foo(CacheableTest.RANDOM.nextLong());
         }
         /**


### PR DESCRIPTION
Insert "asyncUpdate" into annocation called Cacheable. If "asyncUpdate" is true, when this cache expired, updates data after returning. If 'asyncUpdate' is false, when this cache expired, updates data then returns. The default value of 'asyncUpdate' is false.