### PR TITLE
Issue #174 - Inserting correct version/buildnumber here and...

### DIFF
--- a/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
+++ b/src/main/java/com/jcabi/aspects/aj/ImmutabilityChecker.java
@@ -62,10 +62,6 @@ public final class ImmutabilityChecker {
      *
      * <p>Try NOT to change the signature of this method, in order to keep
      * it backward compatible.
-     * @todo #167:30min Inserting correct version/buildnumber
-     *  here and in other instances where Version.CURRENT is
-     *  used (not only in this class, but in every class that
-     *  uses Version.CURRENT) should be covered by a test.
      * @param point Joint point
      */
     @After("initialization((@com.jcabi.aspects.Immutable *).new(..))")

--- a/src/test/java/com/jcabi/aspects/ImmutableTest.java
+++ b/src/test/java/com/jcabi/aspects/ImmutableTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.aspects;
 
+import com.jcabi.aspects.version.Version;
 import java.util.regex.Pattern;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -98,20 +99,17 @@ public final class ImmutableTest {
         try {
             new Mutable();
         } catch (final IllegalStateException ex) {
+            final String message = ex.getMessage();
             MatcherAssert.assertThat(
-                ex.getMessage(),
-                Matchers.not(
-                    Matchers.containsString(
-                        "${projectVersion}"
-                    )
+                message,
+                Matchers.containsString(
+                    Version.CURRENT.projectVersion()
                 )
             );
             MatcherAssert.assertThat(
-                ex.getMessage(),
-                Matchers.not(
-                    Matchers.containsString(
-                        "${buildNumber}"
-                    )
+                message,
+                Matchers.containsString(
+                    Version.CURRENT.buildNumber()
                 )
             );
             return;

--- a/src/test/java/com/jcabi/aspects/ImmutableTest.java
+++ b/src/test/java/com/jcabi/aspects/ImmutableTest.java
@@ -31,9 +31,9 @@ package com.jcabi.aspects;
 
 import com.jcabi.aspects.version.Version;
 import java.util.regex.Pattern;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Test case for {@link Immutable} annotation and its implementation.
@@ -48,6 +48,13 @@ import org.junit.Test;
     "PMD.FinalFieldCouldBeStatic"
 })
 public final class ImmutableTest {
+
+    /**
+     * Exception rule.
+     */
+    @Rule
+    // @checkstyle VisibilityModifierCheck (1 line)
+    public final transient ExpectedException thrown = ExpectedException.none();
 
     /**
      * Immutable can catch mutable classes.
@@ -96,25 +103,10 @@ public final class ImmutableTest {
      */
     @Test
     public void testVersion() {
-        try {
-            new Mutable();
-        } catch (final IllegalStateException ex) {
-            final String message = ex.getMessage();
-            MatcherAssert.assertThat(
-                message,
-                Matchers.containsString(
-                    Version.CURRENT.projectVersion()
-                )
-            );
-            MatcherAssert.assertThat(
-                message,
-                Matchers.containsString(
-                    Version.CURRENT.buildNumber()
-                )
-            );
-            return;
-        }
-        MatcherAssert.assertThat("should not happen.", false);
+        this.thrown.expect(IllegalStateException.class);
+        this.thrown.expectMessage(Version.CURRENT.projectVersion());
+        this.thrown.expectMessage(Version.CURRENT.buildNumber());
+        new Mutable();
     }
 
     /**

--- a/src/test/java/com/jcabi/aspects/ImmutableTest.java
+++ b/src/test/java/com/jcabi/aspects/ImmutableTest.java
@@ -99,10 +99,10 @@ public final class ImmutableTest {
     }
 
     /**
-     * Test Version.
+     * Informs version on error.
      */
     @Test
-    public void testVersion() {
+    public void informsVersionOnError() {
         this.thrown.expect(IllegalStateException.class);
         this.thrown.expectMessage(Version.CURRENT.projectVersion());
         this.thrown.expectMessage(Version.CURRENT.buildNumber());

--- a/src/test/java/com/jcabi/aspects/ImmutableTest.java
+++ b/src/test/java/com/jcabi/aspects/ImmutableTest.java
@@ -30,6 +30,8 @@
 package com.jcabi.aspects;
 
 import java.util.regex.Pattern;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -86,6 +88,35 @@ public final class ImmutableTest {
     @Test(expected = IllegalStateException.class)
     public void catchesTypesMutableByClassInheritance() {
         new MutableByInheritance();
+    }
+
+    /**
+     * Test Version.
+     */
+    @Test
+    public void testVersion() {
+        try {
+            new Mutable();
+        } catch (final IllegalStateException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.not(
+                    Matchers.containsString(
+                        "${projectVersion}"
+                    )
+                )
+            );
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.not(
+                    Matchers.containsString(
+                        "${buildNumber}"
+                    )
+                )
+            );
+            return;
+        }
+        MatcherAssert.assertThat("should not happen.", false);
     }
 
     /**

--- a/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
+++ b/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
@@ -54,7 +54,7 @@ public final class NamedThreadsTest {
     @SuppressWarnings("PMD.DoNotUseThreads")
     public void testVersion() {
         final org.apache.log4j.Logger root = LogManager.getRootLogger();
-        final Level oldLevel = root.getLevel();
+        final Level level = root.getLevel();
         root.setLevel(Level.INFO);
         final StringWriter writer = new StringWriter();
         final WriterAppender appender =
@@ -84,7 +84,7 @@ public final class NamedThreadsTest {
             );
         } finally {
             root.removeAppender(appender);
-            root.setLevel(oldLevel);
+            root.setLevel(level);
         }
     }
 

--- a/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
+++ b/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
@@ -80,23 +80,21 @@ public final class NamedThreadsTest {
         );
     }
 
+    /**
+     * Simple string appender.
+     * @author Haris Peco (snpe60@gmail.com)
+     * @version $Id
+     */
     @SuppressWarnings("PMD.AvoidStringBufferField")
     private class StringAppender extends AppenderSkeleton {
         /**
          * String buffer.
          */
         private final StringBuilder buffer = new StringBuilder();
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public boolean requiresLayout() {
             return false;
         }
-
-        /**
-         * {@inheritDoc}
-         */
         @Override
         // @checkstyle MethodBodyCommentsCheck (2 lines)
         public void close() {
@@ -111,9 +109,6 @@ public final class NamedThreadsTest {
             return this.buffer.toString();
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         protected void append(final LoggingEvent event) {
             this.buffer.append(event.getMessage());

--- a/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
+++ b/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
@@ -86,11 +86,17 @@ public final class NamedThreadsTest {
          * String buffer.
          */
         private final StringBuilder buffer = new StringBuilder();
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public boolean requiresLayout() {
             return false;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         // @checkstyle MethodBodyCommentsCheck (2 lines)
         public void close() {
@@ -105,6 +111,9 @@ public final class NamedThreadsTest {
             return this.buffer.toString();
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         protected void append(final LoggingEvent event) {
             this.buffer.append(event.getMessage());

--- a/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
+++ b/src/test/java/com/jcabi/aspects/aj/NamedThreadsTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.aspects.aj;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.spi.LoggingEvent;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Tests for {@link NamedThreads}.
+ *
+ * @author Haris Peco (snpe60@gmail.com)
+ * @version $Id$
+ */
+public final class NamedThreadsTest {
+    /**
+     * Version test.
+     */
+    @Test
+    @SuppressWarnings("PMD.DoNotUseThreads")
+    public void testVersion() {
+        final org.apache.log4j.Logger root = LogManager.getRootLogger();
+        root.setLevel(org.apache.log4j.Level.INFO);
+        final StringAppender app = new StringAppender();
+        root.addAppender(app);
+        new NamedThreads("test", "desc").newThread(
+            new Runnable() {
+                @Override
+                // @checkstyle MethodBodyCommentsCheck (2 lines)
+                public void run() {
+                    // do nothing
+                }
+            });
+        final String message = app.getBuffer();
+        MatcherAssert.assertThat(
+            message,
+            Matchers.not(
+                Matchers.containsString(
+                    "${projectVersion}"
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            message,
+            Matchers.not(
+                Matchers.containsString(
+                    "${buildNumber}"
+                )
+            )
+        );
+    }
+
+    @SuppressWarnings("PMD.AvoidStringBufferField")
+    private class StringAppender extends AppenderSkeleton {
+        /**
+         * String buffer.
+         */
+        private final StringBuilder buffer = new StringBuilder();
+        @Override
+        public boolean requiresLayout() {
+            return false;
+        }
+
+        @Override
+        // @checkstyle MethodBodyCommentsCheck (2 lines)
+        public void close() {
+            // do nothing
+        }
+
+        /**
+         * Returns string buffer.
+         * @return String buffer
+         */
+        public String getBuffer() {
+            return this.buffer.toString();
+        }
+
+        @Override
+        protected void append(final LoggingEvent event) {
+            this.buffer.append(event.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
The PR: https://github.com/jcabi/jcabi-aspects/issues/174

I have solved as I understand that.
There aren't any place where version/buildnumber is used without Version.CURRENT
I have created test for using Version.CURRENT in ImmutabilityChecker.java

The Version.CURRENt class is also used in com.jcabi.aspects.aj.NamedThreads, but only in logger message. I'm not sure how to test it.

In my opinion, tests are already covered in VersionTest.java,
Please review.