### PR TITLE
specified version in the dependency usage

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -129,7 +129,7 @@ public class MyResource {
   <dependency>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi-aspects</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${project.version}</version>
   </dependency>
 </dependencies>
 +--


### PR DESCRIPTION
it's kind of misleading to show a version that don't exist on maven repos.