### PR TITLE
Added exceptionLevel to allow different log level for exceptions

### DIFF
--- a/src/main/java/com/jcabi/aspects/Loggable.java
+++ b/src/main/java/com/jcabi/aspects/Loggable.java
@@ -133,11 +133,12 @@ public @interface Loggable {
     int value() default Loggable.INFO;
 
     /**
-     * Log level for exceptions. If not defined then the log level of value is used.
+     * Log level for exceptions. If not defined then the log
+     * level of value is used.
      * @return The log level
      */
     int exceptionLevel() default -1;
-    
+
     /**
      * Maximum amount allowed for this method (a warning will be
      * issued if it takes longer).

--- a/src/main/java/com/jcabi/aspects/Loggable.java
+++ b/src/main/java/com/jcabi/aspects/Loggable.java
@@ -133,6 +133,12 @@ public @interface Loggable {
     int value() default Loggable.INFO;
 
     /**
+     * Log level for exceptions. If not defined then the log level of value is used.
+     * @return The log level
+     */
+    int exceptionLevel() default -1;
+    
+    /**
      * Maximum amount allowed for this method (a warning will be
      * issued if it takes longer).
      * @since 0.7.6

--- a/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
@@ -66,6 +66,11 @@ import org.aspectj.lang.reflect.MethodSignature;
     )
 public final class MethodLogger {
 
+	/**
+     * constant used to disregard logging.
+     */
+    private static final int IGNORE_EXCEPTION_LEVEL = -1;
+    
     /**
      * Currently running methods.
      */
@@ -240,7 +245,9 @@ public final class MethodLogger {
                 } else {
                     origin = "somewhere";
                 }
-                level = annotation.exceptionLevel() == -1 ? level : annotation.exceptionLevel();
+                if(annotation.exceptionLevel() != IGNORE_EXCEPTION_LEVEL) {
+                	level = annotation.exceptionLevel();
+                }
                 if (LogHelper.enabled(level, method.getDeclaringClass())) {
                     LogHelper.log(
                         level,

--- a/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
@@ -66,11 +66,11 @@ import org.aspectj.lang.reflect.MethodSignature;
     )
 public final class MethodLogger {
 
-	/**
+    /**
      * constant used to disregard logging.
      */
     private static final int IGNORE_EXCEPTION_LEVEL = -1;
-    
+
     /**
      * Currently running methods.
      */
@@ -245,8 +245,8 @@ public final class MethodLogger {
                 } else {
                     origin = "somewhere";
                 }
-                if(annotation.exceptionLevel() != IGNORE_EXCEPTION_LEVEL) {
-                	level = annotation.exceptionLevel();
+                if (annotation.exceptionLevel() != IGNORE_EXCEPTION_LEVEL) {
+                    level = annotation.exceptionLevel();
                 }
                 if (LogHelper.enabled(level, method.getDeclaringClass())) {
                     LogHelper.log(

--- a/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
@@ -240,6 +240,7 @@ public final class MethodLogger {
                 } else {
                     origin = "somewhere";
                 }
+                level = annotation.exceptionLevel() == -1 ? level : annotation.exceptionLevel();
                 if (LogHelper.enabled(level, method.getDeclaringClass())) {
                     LogHelper.log(
                         level,

--- a/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
@@ -67,9 +67,9 @@ import org.aspectj.lang.reflect.MethodSignature;
 public final class MethodLogger {
 
     /**
-     * constant used to disregard logging.
+     * Constant used to disregard logging.
      */
-    private static final int IGNORE_EXCEPTION_LEVEL = -1;
+    private static final int DEROGATION_OFF = -1;
 
     /**
      * Currently running methods.
@@ -245,7 +245,7 @@ public final class MethodLogger {
                 } else {
                     origin = "somewhere";
                 }
-                if (annotation.exceptionLevel() != IGNORE_EXCEPTION_LEVEL) {
+                if (annotation.exceptionLevel() != MethodLogger.DEROGATION_OFF) {
                     level = annotation.exceptionLevel();
                 }
                 if (LogHelper.enabled(level, method.getDeclaringClass())) {

--- a/src/test/java/com/jcabi/aspects/LoggableTest.java
+++ b/src/test/java/com/jcabi/aspects/LoggableTest.java
@@ -57,6 +57,8 @@ final class LoggableTest {
      * Foo toString result.
      */
     private static final transient String RESULT = "some text";
+    private static final transient String DEBUG_LOG = "DEBUG";
+    private static final transient String ERROR_LOG = "ERROR";
 
     @Test
     void logsSimpleCall() {
@@ -161,7 +163,29 @@ final class LoggableTest {
             Matchers.stringContainsInOrder(shorts)
         );
     }
-
+    
+    @Test
+    void logsWithErrorExceptionLevel() throws Exception {
+        final StringWriter writer = new StringWriter();
+        Logger.getRootLogger().addAppender(
+            new WriterAppender(new SimpleLayout(), writer)
+        );
+        try {
+        	LoggableTest.Foo.errorExceptionLogging();
+        } catch(Exception e) {
+        	// Assert prepend DEBUG
+        	MatcherAssert.assertThat(
+    			writer.toString(),
+    			new LoggableTest.RegexContainsMatcher(DEBUG_LOG)
+			);
+        	// Assert exception ERROR
+        	MatcherAssert.assertThat(
+    			writer.toString(),
+    			new LoggableTest.RegexContainsMatcher(ERROR_LOG)
+			);        	
+        }
+    }
+    
     @Test
     void logsWithExplicitLoggerName() throws Exception {
         final StringWriter writer = new StringWriter();
@@ -234,6 +258,15 @@ final class LoggableTest {
         @Loggable(value = Loggable.DEBUG, name = "test-logger", prepend = true)
         public static String explicitLoggerName() {
             return LoggableTest.Foo.hiddenText();
+        }
+        
+        /**
+         * Method annotated with Loggable specifying exceptionLevel.
+         * @return A String
+         */
+        @Loggable(value = Loggable.DEBUG, exceptionLevel = Loggable.ERROR, prepend = true)
+        public static String errorExceptionLogging() {
+        	throw new RuntimeException();
         }
 
         /**

--- a/src/test/java/com/jcabi/aspects/LoggableTest.java
+++ b/src/test/java/com/jcabi/aspects/LoggableTest.java
@@ -57,7 +57,15 @@ final class LoggableTest {
      * Foo toString result.
      */
     private static final transient String RESULT = "some text";
+
+    /**
+     * Log prefix for DEBUG.
+     */
     private static final transient String DEBUG_LOG = "DEBUG";
+
+    /**
+     * Log prefix for ERROR.
+     */
     private static final transient String ERROR_LOG = "ERROR";
 
     @Test
@@ -163,7 +171,7 @@ final class LoggableTest {
             Matchers.stringContainsInOrder(shorts)
         );
     }
-    
+
     @Test
     void logsWithErrorExceptionLevel() throws Exception {
         final StringWriter writer = new StringWriter();
@@ -171,21 +179,19 @@ final class LoggableTest {
             new WriterAppender(new SimpleLayout(), writer)
         );
         try {
-        	LoggableTest.Foo.errorExceptionLogging();
-        } catch(Exception e) {
-        	// Assert prepend DEBUG
-        	MatcherAssert.assertThat(
-    			writer.toString(),
-    			new LoggableTest.RegexContainsMatcher(DEBUG_LOG)
+            LoggableTest.Foo.errorExceptionLogging();
+        } catch (final UnsupportedOperationException exception) {
+            MatcherAssert.assertThat(
+                writer.toString(),
+                new LoggableTest.RegexContainsMatcher(LoggableTest.DEBUG_LOG)
             );
-        	// Assert exception ERROR
-        	MatcherAssert.assertThat(
-    			writer.toString(),
-    			new LoggableTest.RegexContainsMatcher(ERROR_LOG)
-            );        	
+            MatcherAssert.assertThat(
+                writer.toString(),
+                new LoggableTest.RegexContainsMatcher(LoggableTest.ERROR_LOG)
+            );
         }
     }
-    
+
     @Test
     void logsWithExplicitLoggerName() throws Exception {
         final StringWriter writer = new StringWriter();
@@ -259,14 +265,14 @@ final class LoggableTest {
         public static String explicitLoggerName() {
             return LoggableTest.Foo.hiddenText();
         }
-        
+
         /**
          * Method annotated with Loggable specifying exceptionLevel.
          * @return A String
          */
         @Loggable(value = Loggable.DEBUG, exceptionLevel = Loggable.ERROR, prepend = true)
         public static String errorExceptionLogging() {
-        	throw new RuntimeException();
+            throw new UnsupportedOperationException();
         }
 
         /**

--- a/src/test/java/com/jcabi/aspects/LoggableTest.java
+++ b/src/test/java/com/jcabi/aspects/LoggableTest.java
@@ -177,12 +177,12 @@ final class LoggableTest {
         	MatcherAssert.assertThat(
     			writer.toString(),
     			new LoggableTest.RegexContainsMatcher(DEBUG_LOG)
-			);
+            );
         	// Assert exception ERROR
         	MatcherAssert.assertThat(
     			writer.toString(),
     			new LoggableTest.RegexContainsMatcher(ERROR_LOG)
-			);        	
+            );        	
         }
     }
     


### PR DESCRIPTION
Solution for issues: #259  #236 
Solution allows for new property exceptionLevel on Loggable annotation, which, if defined, will log the exception on the given log level, else it will use the log level defined on the value property, making the solution backward compatible.