### PR TITLE
Add logException level to @Loggable for configurable exception log level

### DIFF
--- a/src/main/java/com/jcabi/aspects/Loggable.java
+++ b/src/main/java/com/jcabi/aspects/Loggable.java
@@ -186,6 +186,25 @@ public @interface Loggable {
     String name() default "";
 
     /**
+     * Log level to use when an exception is thrown. When set to a value
+     * other than {@code -1}, exceptions are logged at this level instead
+     * of the level defined by {@link #value()}. This is useful in
+     * production environments where the default log level is set to WARN
+     * or above: you can keep the method itself logging at INFO or DEBUG
+     * while still making exceptions visible at ERROR.
+     *
+     * <pre> &#64;Loggable(value = Loggable.DEBUG, logException = Loggable.ERROR)
+     * void process() {
+     *   // exceptions logged at ERROR even though the method logs at DEBUG
+     * }</pre>
+     *
+     * @since 0.30
+     * @return The log level for exceptions, or {@code -1} to use the
+     *  same level as the method
+     */
+    int logException() default -1;
+
+    /**
      * Identifies an exception that is never logged by {@link Loggable} if/when
      * being thrown out of an annotated method.
      *

--- a/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
+++ b/src/main/java/com/jcabi/aspects/aj/MethodLogger.java
@@ -215,9 +215,11 @@ public final class MethodLogger {
                 } else {
                     origin = "somewhere";
                 }
-                if (LogHelper.enabled(level, method.getDeclaringClass())) {
+                final int exlevel = annotation.logException() >= 0
+                    ? annotation.logException() : level;
+                if (LogHelper.enabled(exlevel, method.getDeclaringClass())) {
                     LogHelper.log(
-                        level,
+                        exlevel,
                         method.getDeclaringClass(),
                         Logger.format(
                             "%s: thrown %s out of %s in %[nano]s",

--- a/src/test/java/com/jcabi/aspects/LoggableTest.java
+++ b/src/test/java/com/jcabi/aspects/LoggableTest.java
@@ -138,6 +138,22 @@ final class LoggableTest {
     }
 
     @Test
+    void logsExceptionAtConfiguredLevel() {
+        final StringWriter writer = new StringWriter();
+        Logger.getRootLogger().addAppender(
+            new WriterAppender(new SimpleLayout(), writer)
+        );
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new LoggableTest.Bar().throwAtConfiguredLevel()
+        );
+        MatcherAssert.assertThat(
+            writer.toString(),
+            Matchers.containsString("ERROR")
+        );
+    }
+
+    @Test
     void logsWithExplicitLoggerName() throws Exception {
         final StringWriter writer = new StringWriter();
         Logger.getRootLogger().addAppender(
@@ -282,6 +298,20 @@ final class LoggableTest {
         @Loggable(ignore = { IOException.class, RuntimeException.class })
         private void doThrow() {
             throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * Class with a method that uses logException to control exception log level.
+     * @since 0.0.0
+     */
+    private static final class Bar {
+        /**
+         * Throws with exception logged at ERROR even though method is DEBUG.
+         */
+        @Loggable(value = Loggable.DEBUG, logException = Loggable.ERROR)
+        public void throwAtConfiguredLevel() {
+            throw new IllegalStateException("test");
         }
     }
 


### PR DESCRIPTION
Fixes #259.

## Summary

- Adds `logException()` attribute to `@Loggable` (default `-1`, meaning
  "log at the same level as the method")
- When `logException` is set to a non-negative level (e.g. `Loggable.ERROR`),
  `MethodLogger` uses that level instead of the method's own level when
  logging thrown exceptions
- Adds a test that verifies the exception is indeed logged at the
  configured level

## Usage

```java
@Loggable(value = Loggable.DEBUG, logException = Loggable.ERROR)
void process() {
    // normal exit logged at DEBUG; any exception logged at ERROR
}
```

This is useful in production environments where the default log threshold
is WARN or above: method entry/exit stays at DEBUG while exceptions
remain visible at ERROR.

## Test plan

- [x] Existing 70 tests all pass with no regressions
- [x] New `logsExceptionAtConfiguredLevel` test fails before the fix and
  passes after it (red-to-green demonstrated by two separate commits)

https://claude.ai/code/session_01WQMq6Mu1LgLbRWXwd6yyrh